### PR TITLE
chore: standardize CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aplwin-sf"
-version = "0.1.0"
+version = "0.1.1"
 description = "Read APL+Win component files (.sf) from Python"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Standardize all CI/publish workflows to a single `ci.yml` pattern:

- Single `ci.yml` file with test + publish jobs
- Trigger: push to main, push tags `v*`, pull_request to main, workflow_dispatch
- Publish job gated on tests (`needs: test`) and tag push (`if: startsWith(github.ref, 'refs/tags/v')`)
- `environment: pypi` on all publish jobs
- OIDC trusted publishing via `pypa/gh-action-pypi-publish@release/v1`
- Removed separate publish/test-pypi files, Sigstore signing, artifact upload/download
- Added `workflow_dispatch` trigger for manual runs

Generated by maintain tooling.